### PR TITLE
Add nbstripoutput pip to image

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,3 +20,4 @@ dependencies:
   - pip:
     - nbgitpuller  # nbgitpuller on conda-forge seems to be outdated so use pip
     - jupyterlab-limit-output
+    - nbstripoutput

--- a/environment.yml
+++ b/environment.yml
@@ -20,4 +20,4 @@ dependencies:
   - pip:
     - nbgitpuller  # nbgitpuller on conda-forge seems to be outdated so use pip
     - jupyterlab-limit-output
-    - nbstripoutput
+    - nbstripout


### PR DESCRIPTION
To help students who end up with an unresponsive Jupyter because of very large output in files.  A workaround for the issue in xues-sql reported here: https://github.com/jupyter-xeus/xeus-sql/issues/59